### PR TITLE
Switch to chalk for coloring and add time-grunt/load-grunt-tasks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,7 +1,9 @@
 'use strict';
 
 module.exports = function (grunt) {
-  require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+  // Load any grunt plugins found in package.json.
+  require('load-grunt-tasks')(grunt);
+  require('time-grunt')(grunt);
 
   grunt.initConfig({
     'link-checker': {

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "crawler"
   ],
   "dependencies": {
+    "chalk": "^1.0.0",
     "cheerio": "^0.19.0",
-    "colors": "^1.0.3",
     "simplecrawler": "^0.3.10"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "grunt-contrib-connect": "^0.10.1",
     "grunt-contrib-jshint": "^0.11.1",
     "grunt-release": "^0.12.0",
-    "matchdep": "^0.3.0"
+    "load-grunt-tasks": "^3.1.0",
+    "time-grunt": "^1.1.0"
   },
   "engines": {
     "node": ">=0.10.0"

--- a/tasks/link-checker.js
+++ b/tasks/link-checker.js
@@ -10,7 +10,7 @@
 
 var Crawler = require('simplecrawler');
 var cheerio = require('cheerio');
-require('colors');
+var chalk = require('chalk');
 
 module.exports = function (grunt) {
   grunt.registerMultiTask('link-checker', 'Checks your site for broken links after a build.', function () {
@@ -29,24 +29,24 @@ module.exports = function (grunt) {
     crawler
       .on('fetch404', function(queueItem, response) {
         errors = true;
-        grunt.log.error('Resource not found linked from ' + queueItem.referrer.cyan + ' to', queueItem.url.magenta);
+        grunt.log.error('Resource not found linked from ' + chalk.cyan(queueItem.referrer) + ' to', chalk.magenta(queueItem.url));
         grunt.log.error('Status code: ' + response.statusCode);
       })
       .on('fetcherror', function(queueItem, response) {
         errors = true;
-        grunt.log.error('Trouble fetching the following resource linked from ' + queueItem.referrer.cyan + ' to', queueItem.url.magenta);
+        grunt.log.error('Trouble fetching the following resource linked from ' + chalk.cyan(queueItem.referrer) + ' to', chalk.magenta(queueItem.url));
         grunt.log.error('Status code: ' + response.statusCode);
       })
       .on('fetchtimeout', function(queueItem) {
         errors = true;
-        grunt.log.error('Timeout fetching the following resource linked from ' + queueItem.referrer.cyan + ' to', queueItem.url.magenta);
+        grunt.log.error('Timeout fetching the following resource linked from ' + chalk.cyan(queueItem.referrer) + ' to', chalk.magenta(queueItem.url));
       })
       .on('fetchclienterror', function(queueItem) {
         errors = true;
         if (!queueItem.referrer) {
-          return grunt.log.error('Error fetching `site` URL: ' + queueItem.url.magenta);
+          return grunt.log.error('Error fetching `site` URL: ' + chalk.magenta(queueItem.url));
         }
-        grunt.log.error('Client error fetching the following resource linked from ' + queueItem.referrer ? queueItem.referrer.cyan : site + ' to', queueItem.url.magenta);
+        grunt.log.error('Client error fetching the following resource linked from ' + queueItem.referrer ? chalk.cyan(queueItem.referrer) : site + ' to', chalk.magenta(queueItem.url));
       })
       .on('complete', function() {
         if (!errors) {
@@ -69,11 +69,11 @@ module.exports = function (grunt) {
         if (queueItem.url.indexOf('#') !== -1) {
           try {
             if ($(queueItem.url.slice(queueItem.url.indexOf('#'))).length === 0) {
-              grunt.log.error('Error finding content with the following fragment identifier linked from ' + queueItem.referrer.cyan + ' to', queueItem.url.magenta);
+              grunt.log.error('Error finding content with the following fragment identifier linked from ' + chalk.cyan(queueItem.referrer) + ' to', chalk.magenta(queueItem.url));
               errors = true;
             }
           } catch (e) {
-            grunt.log.error('The following URL was formatted incorrectly linked from ' + queueItem.referrer.cyan + ' to', queueItem.url.magenta);
+            grunt.log.error('The following URL was formatted incorrectly linked from ' + chalk.cyan(queueItem.referrer) + ' to', chalk.magenta(queueItem.url));
             errors = true;
           }
         }


### PR DESCRIPTION
@ChrisWren: I hope this helps see #12. Sorry for not splitting up the patches, but let me know if you want me to change anything.

Note, that I added `localhost` and  `9001` as the default if they are not set.

Two things I've noticed so far after switching to node.js 0.10.38 to make this work:

1. Isn't `grunt-release` unused?
2. The instructions should mention `grunt-contrib-connect` in the examples for `localhost`.

~~EDIT: Hmm, Travis doesn't seem to be enabled for PRs... You can check https://travis-ci.org/XhmikosR/grunt-link-checker/builds/57308777 in the meantime.~~
