### PR TITLE
Update dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,15 +28,15 @@
   "dependencies": {
     "chalk": "^1.0.0",
     "cheerio": "^0.19.0",
-    "simplecrawler": "^0.3.10"
+    "simplecrawler": "^0.4.1"
   },
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-contrib-connect": "^0.10.1",
-    "grunt-contrib-jshint": "^0.11.1",
+    "grunt-contrib-jshint": "^0.11.2",
     "grunt-release": "^0.12.0",
     "load-grunt-tasks": "^3.1.0",
-    "time-grunt": "^1.1.0"
+    "time-grunt": "^1.1.1"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
Reason for this is to force the new deps when you release a new version.