### PR TITLE
Correct bug when checking for ids with dots

### DIFF
--- a/tasks/link-checker.js
+++ b/tasks/link-checker.js
@@ -68,7 +68,7 @@ module.exports = function (grunt) {
 
         if (queueItem.url.indexOf('#') !== -1) {
           try {
-            if ($(queueItem.url.slice(queueItem.url.indexOf('#'))).length === 0) {
+            if ($('[id="' + queueItem.url.slice(queueItem.url.indexOf('#')+1) + '"]').length === 0) {
               grunt.log.error('Error finding content with the following fragment identifier linked from ' + chalk.cyan(queueItem.referrer) + ' to', chalk.magenta(queueItem.url));
               errors = true;
             }


### PR DESCRIPTION
If an id has dots (for example fig4.5.1) then cheerio doesn't work correctly. This makes the crawler fail although the anchor does exist.