### PR TITLE
Add support for . in anchors

### DIFF
--- a/tasks/link-checker.js
+++ b/tasks/link-checker.js
@@ -19,6 +19,7 @@ module.exports = function (grunt) {
     var options = this.options();
     var errors = false;
     var site = this.data.site;
+    var dotRE = /\./g;
 
     grunt.log.ok('Checking for broken links at: ' + site + (options.initialPort ? ':' + options.initialPort : ''));
     var crawler = new Crawler(site);
@@ -68,7 +69,7 @@ module.exports = function (grunt) {
 
         if (queueItem.url.indexOf('#') !== -1) {
           try {
-            if ($(queueItem.url.slice(queueItem.url.indexOf('#'))).length === 0) {
+            if ($(queueItem.url.slice(queueItem.url.indexOf('#')).replace(dotRE, '\\.')).length === 0) {
               grunt.log.error('Error finding content with the following fragment identifier linked from ' + chalk.cyan(queueItem.referrer) + ' to', chalk.magenta(queueItem.url));
               errors = true;
             }

--- a/test/fixtures/index.html
+++ b/test/fixtures/index.html
@@ -8,5 +8,7 @@
   <a href="#test"></a>
   <a href="/index2.html#link"></a>
   <h2 id="test"></h2>
+  <a href="#.dot"></a>
+  <h2 id=".dot"></h2>
 </body>
 </html>


### PR DESCRIPTION
It's valid to have `.` in an anchor. Example:

    <a href="#.foo"></a>
    <a id=".foo"></a>

But it's not valid to use `#.foo` as a selector. The solution is to
escape the `.`.

See http://stackoverflow.com/questions/35980786/why-is-id-a-bad-selector-in-css-jquery-yet-it-works-in-an-html-anchor